### PR TITLE
밥팟 만들기 : 키워드 재선택 로직 추가

### DIFF
--- a/public/data/ChatResponse.ts
+++ b/public/data/ChatResponse.ts
@@ -7,11 +7,16 @@ export enum ResponseType {
   ELSE = 'ELSE',
 }
 
+/**
+ * doneClicking
+ * 카테고리 > 키워드까지 선택하면 재선택 불가,
+ * 카테고리만 선택한 상황에서는 카테고리 재선택가능 (단, 직전의 카테고리만 선택한 것만 재선택 가능)
+ */
 export type ChatType = {
   speaker: 'user' | 'ai'
   content: string
   type?: ResponseType
-  doneClicking: boolean // 메인카테고리 or 키워드 선택하였는지 여부 (재선택 불가 로직을 위한 인자)
+  doneClicking: boolean // 키워드 선택하였는지 여부 (재선택 불가 로직을 위한 인자)
   lastMainCategory?: MainCategoriesType
   lastKeywords?: string[]
 }
@@ -47,7 +52,7 @@ export class Chatting {
       speaker: 'ai',
       // Todo: 메인 카테고리 선택에 따른 이름 변동이 되도록 처리
       // content: `${mainCategory}을 선택하셨네요.\n\n더 좋은 응답을 생성하기 위해 어떤 종류의 ${mainCategory}을 원하는지 추가 키워드를 선택해주세요.`,
-      content: `카테고리 선택을 완료하셨군요!\n\n더 좋은 응답을 생성하기 위해 어떤 종류의 ${mainCategory}을 원하는지 추가 키워드를 선택해주세요.`,
+      content: `카테고리 선택을 완료하셨군요!\n\n더 좋은 응답을 생성하기 위해 어떤 종류의 음식을 원하는지 추가 키워드를 선택해주세요.`,
       type: ResponseType.MAIN_CATEGORY,
       doneClicking: false,
       lastMainCategory: undefined,

--- a/src/app/(headerless)/part/page.tsx
+++ b/src/app/(headerless)/part/page.tsx
@@ -7,13 +7,14 @@ import KakaoMap from '@components/common/KakaoMap'
 import Chatroom from '@components/part/ChatRoom'
 import PlaceList from '@components/part/PlaceList'
 import RefuseModal from '@components/part/RefuseModal'
+import { Input } from '@components/ui/input'
 import { URL } from '@lib/constants/routes'
 import { ChattingType, CreateChatType } from '@lib/HTTP/API/chat'
 import { useMutationStore } from '@lib/HTTP/tanstack-query'
+import LucideIcon from '@lib/provider/LucideIcon'
 import { GeoType } from '@lib/types/part/part'
-import { cn } from '@lib/utils/utils'
 import { KTB_Position } from '@public/data'
-import { MainCategories, MainCategoriesType } from '@public/data/categories'
+import { MainCategoriesType } from '@public/data/categories'
 import { Chatting, ChatType } from '@public/data/ChatResponse'
 import { placeListDummyData } from '@public/data/restaurant'
 import LogoImage from '@public/images/logo.svg'
@@ -54,6 +55,8 @@ const PartPage = (): ReactNode => {
   }, [])
 
   /** 좌측 검색리스트 관련 상태 */
+  const [searchInput, setSearchInput] = useState<string>('')
+  const [isComposing, setIsComposing] = useState<boolean>(false)
   const [placeList, setPlaceList] = useState<placeDTO[]>(placeListDummyData)
 
   /** 채팅 관련 상태 */
@@ -251,26 +254,30 @@ const PartPage = (): ReactNode => {
           밥팟
         </Link>
 
-        <div className='flex flex-col items-start justify-start gap-1 pl-8'>
-          <span className='font-dohyeon text-2xl'>선호 음식</span>
-          <span className='text-xss text-rcDarkGray'>* 선호 음식을 눌러 카테부 주변의 맛집을 추천 받아보세요!</span>
-
-          <ul className='mb-2 grid w-full grid-cols-4 grid-rows-2 gap-2'>
-            {MainCategories.map(cat => (
-              <li
-                onClick={() => mainCategoryClickHandler(cat)}
-                className={cn(
-                  cat === category.mainCategory && 'bg-rcKakaoYellow hover:bg-rcKakaoYellowHover',
-                  'flex cursor-pointer items-center justify-center rounded-md border-[0.5px] border-solid border-rcGray px-1 py-2 text-[10px] font-semibold hover:bg-rcKakaoYellow',
-                )}
-                key={cat}
-              >
-                {cat}
-              </li>
-            ))}
-          </ul>
+        <div className='relative my-3 flex w-full flex-col items-start justify-start gap-1 pl-8'>
+          <span className='font-dohyeon text-2xl'>밥팟 음식점</span>
+          <div className='flex w-full items-center justify-start border-b-2 border-solid border-rcKakaoYellow'>
+            <LucideIcon name='Search' />
+            <Input
+              type='text'
+              placeholder='식당 이름을 검색해보세요'
+              className='h-9 w-full rounded-none border-0 py-0 text-sm shadow-none outline-none focus:outline-none focus-visible:ring-0 sm:w-60'
+              value={searchInput}
+              onChange={e => setSearchInput(e.target.value)}
+              // onKeyDown={e => {
+              //   if (e.key === 'Enter' && !isComposing) {
+              //     e.preventDefault()
+              //     refetch()
+              //   }
+              // }}
+              onCompositionStart={() => setIsComposing(true)} // 한글 조합 시작
+              onCompositionEnd={() => setIsComposing(false)} // 한글 조합 끝
+            />
+          </div>
         </div>
-
+        <div className='self-end'>
+          총 <span className='text-rcBlue'>12</span>건
+        </div>
         <div className='my-1 h-[1px] w-full bg-rcLightGray' />
 
         <PlaceList
@@ -288,6 +295,7 @@ const PartPage = (): ReactNode => {
         </span>
 
         {/* 채팅내용 */}
+
         <Chatroom
           category={category}
           updateCategory={updateCategory}

--- a/src/app/(headerless)/part/page.tsx
+++ b/src/app/(headerless)/part/page.tsx
@@ -72,8 +72,6 @@ const PartPage = (): ReactNode => {
   const [userChat, setUserChat] = useState<string>('')
   const [chats, setChats] = useState<ChatType[]>([Chatting.StartResponse()])
 
-  console.log(chats)
-
   /** 지도 관련 상태 */
   const [center, setCenter] = useState<GeoType>(KTB_Position)
   const [focusedPlaceId, setFocusedPlaceId] = useState<number>()
@@ -150,9 +148,6 @@ const PartPage = (): ReactNode => {
   }
 
   const restartMainCategoryClickHandler = (chat_index: number) => {
-    console.log('entered restart main cateogry')
-    console.log('main cateogry: ', category)
-
     // 재시작
     if (chat_index !== undefined) {
       const newChat = chats.map((chat, index) =>

--- a/src/app/(headerless)/part/page.tsx
+++ b/src/app/(headerless)/part/page.tsx
@@ -72,6 +72,8 @@ const PartPage = (): ReactNode => {
   const [userChat, setUserChat] = useState<string>('')
   const [chats, setChats] = useState<ChatType[]>([Chatting.StartResponse()])
 
+  console.log(chats)
+
   /** 지도 관련 상태 */
   const [center, setCenter] = useState<GeoType>(KTB_Position)
   const [focusedPlaceId, setFocusedPlaceId] = useState<number>()
@@ -92,10 +94,7 @@ const PartPage = (): ReactNode => {
 
   // 카테고리 함수
   const mainCategoryClickHandler = (mainCategory: MainCategoriesType, chat_index?: number) => {
-    setCategory({
-      ...category,
-      mainCategory,
-    })
+    updateCategory({ mainCategory: mainCategory })
     // 채팅에서 클릭한 경우
     if (chat_index !== undefined) {
       const newChat = chats.map((chat, index) =>
@@ -117,10 +116,7 @@ const PartPage = (): ReactNode => {
     let newKeywords: string[] | ''
     if (!category.keywords) {
       newKeywords = [keyword]
-      setCategory(prev => ({
-        ...prev,
-        keywords: newKeywords,
-      }))
+      updateCategory({ keywords: newKeywords })
     }
     // 기존에 키워드가 있었던 경우
     else {
@@ -131,14 +127,14 @@ const PartPage = (): ReactNode => {
           ? [...category.keywords, keyword]
           : category.keywords
 
-      setCategory(prev => ({
-        ...prev,
-        keywords: newKeywords,
-      }))
+      updateCategory({ keywords: newKeywords })
     }
   }
 
   const restartClickHandler = (chat_index: number) => {
+    // 카테고리, 키워드 초기화
+    updateCategory({ keywords: '', mainCategory: '' })
+
     // 재시작
     if (chat_index !== undefined) {
       const newChat = chats.map((chat, index) =>
@@ -151,6 +147,27 @@ const PartPage = (): ReactNode => {
       )
       setChats(newChat)
     }
+  }
+
+  const restartMainCategoryClickHandler = (chat_index: number) => {
+    console.log('entered restart main cateogry')
+    console.log('main cateogry: ', category)
+
+    // 재시작
+    if (chat_index !== undefined) {
+      const newChat = chats.map((chat, index) =>
+        chat_index === index
+          ? {
+              ...chat,
+              doneClicking: true,
+              lastMainCategory: category.mainCategory as MainCategoriesType,
+            }
+          : chat,
+      )
+      setChats(newChat)
+    }
+    // 카테고리, 키워드 초기화
+    updateCategory({ keywords: '', mainCategory: '' })
   }
 
   const { mutate: ChattingMutate, isPending: isChatting } = useMutationStore<ChattingType>(['chatting'])
@@ -308,6 +325,7 @@ const PartPage = (): ReactNode => {
           keywordClickHandler={keywordClickHandler}
           sendKeywordSelection={sendKeywordSelection}
           restartClickHandler={restartClickHandler}
+          restartMainCategoryClickHandler={restartMainCategoryClickHandler}
           isChatting={isChatting}
         />
       </div>

--- a/src/components/part/AIChatButtonFrame.tsx
+++ b/src/components/part/AIChatButtonFrame.tsx
@@ -24,7 +24,7 @@ const AIChatButtonFrame = ({ content, clickHandler, children }: AIChatButtonFram
             }}
           />
           <Button onClick={clickHandler} variant='rcGreen' className='mt-2 w-full font-pretendard text-xs font-medium'>
-            키워드 재선택하기
+            선호 음식 재선택하기
           </Button>
         </div>
       </div>

--- a/src/components/part/ChatRoom.tsx
+++ b/src/components/part/ChatRoom.tsx
@@ -26,6 +26,7 @@ interface ChatroomProps {
   keywordClickHandler: (keyword: string, mainCategory: MainCategoriesType, chat_index: number) => void
   sendKeywordSelection: (keywords: string[], mainCategory: MainCategoriesType, chat_index: number) => void
   restartClickHandler: (chat_index: number) => void
+  restartMainCategoryClickHandler: (chat_index: number) => void
   isChatting: boolean
 }
 
@@ -41,6 +42,7 @@ const Chatroom = ({
   keywordClickHandler,
   sendKeywordSelection,
   restartClickHandler,
+  restartMainCategoryClickHandler,
   isChatting,
 }: ChatroomProps): ReactNode => {
   const chatContainerRef = useRef<HTMLDivElement>(null)
@@ -74,11 +76,15 @@ const Chatroom = ({
       // 키워드 변경
       keywordClickHandler(keyword, mainCategory, chat_index)
     }
+    static restartMainCategory = (chat_index: number) => {
+      // 채팅 잠금
+      restartMainCategoryClickHandler(chat_index)
+
+      // 초기 채팅 더하기
+      addChatHandler(Chatting.StartResponse())
+    }
 
     static restart = (chat_index: number) => {
-      // 카테고리, 키워드 초기화
-      updateCategory({ keywords: '', mainCategory: '' })
-
       // 채팅 잠금
       restartClickHandler(chat_index)
 
@@ -171,6 +177,14 @@ const Chatroom = ({
                     </li>
                   ))}
                 </ul>
+                <Button
+                  disabled={chat.doneClicking ? true : false}
+                  onClick={() => ClickHandlers.restartMainCategory(chat_index)}
+                  variant='rcDarkGray'
+                  className='w-full font-pretendard text-xs font-medium'
+                >
+                  선호 음식 재선택하기
+                </Button>
                 <Button
                   disabled={category.keywords === '' || chat.doneClicking ? true : false}
                   onClick={() => searchHandler(chat_index)}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,6 +21,7 @@ const buttonVariants = cva(
         rcKakaoLightYellow: 'bg-rcKakaoLightYellow text-black hover:opacity-75 shadow-rc-shadow',
         rcGreen: 'bg-rcGreen text-black hover:bg-rcGreenHover shadow-rc-shadow',
         rcLightGray: 'bg-rcLightGray text-black hover:bg-rcGray shadow-rc-shadow',
+        rcDarkGray: 'bg-rcDarkGray hover:bg-rcDarkGrayHover shadow-rc-shadow text-rcWhite',
       },
       size: {
         default: 'h-9 px-4 py-2',

--- a/src/lib/colors/colors.ts
+++ b/src/lib/colors/colors.ts
@@ -19,6 +19,7 @@ export const colorSet = {
   rcKakaoYellowHover: config.theme.extend.colors.rcKakaoYellowHover,
   rcGreenHover: config.theme.extend.colors.rcGreenHover,
   rcBlueHover: config.theme.extend.colors.rcBlueHover,
+  rcDarkGrayHover: config.theme.extend.colors.rcDarkGrayHover,
 }
 
 export type ColorType = keyof typeof colorSet

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -66,6 +66,7 @@ export default {
         rcKakaoYellowHover: '#FFDC44',
         rcGreenHover: '#B9E49C',
         rcBlueHover: '#3470B9',
+        rcDarkGrayHover: '#7D7F82',
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## 기능 설명

기존에는 선호 음식을 선택한 이후, 키워드 선택 과정에서 선호 음식을 재선택할 수 없었습니다.

## 문제

음식 종류를 다시 선택하고 싶은 유저의 요청에 따라, 선호 음식을 재선택할 수 있도록 UI 변경 + 로직 추가하였습니다.

### 구현방법

아래 사진과 같이, "선호 음식 재선택하기" 버튼을 추가하여, 유저의 선택지를 넓혔습니다.

![image](https://github.com/user-attachments/assets/8aef8f3b-940b-49fd-b538-e7d1083937d4)

해당 상황에 코드를 추가하는 함수를 추가하였습니다.

### TODO

채팅관련 코드가 너무 번잡하고 어지럽다고 생각이 듭니다.
한곳에 모아두고 관리하도록 리펙토링이 필요해보입니다.